### PR TITLE
[FIX] Updates Slack link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -13,7 +13,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/Nixtla",
-      "slack": "https://join.slack.com/t/nixtlaworkspace/shared_invite/zt-135dssye9-fWTzMpv2WBthq8NK0Yvu6A",
+      "slack": "https://join.slack.com/t/nixtlacommunity/shared_invite/zt-3ohywcamu-bpYf70GsEo_awLCvVoa0rQ",
       "twitter": "https://twitter.com/nixtlainc"
     }
   },


### PR DESCRIPTION
Currently Slack link doesn't work. This link will also expire in 30 days but it'll work until Max can create a long term url.