### PR TITLE
feat: add PostHog analytics to nixtlaverse docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -24,6 +24,10 @@
     "gtm": {
       "tagId": "GTM-TBJ64S3X"
     },
+    "posthog": {
+      "apiKey": "phc_hblNl72piphlbRCYfGM8QkgazW9NNrDrP6dMbGzMp82",
+      "apiHost": "https://d.nixtla.io"
+    },
     "intercom": {
       "appId": "j7y9c2ep"
     }


### PR DESCRIPTION
## Summary

- Add PostHog integration to Mintlify docs config
- Uses custom domain `d.nixtla.io` as `apiHost` to bypass ad blockers
- Tracks pageviews and user interactions alongside existing GTM and Intercom

## Test Plan

- [x] Verify Mintlify preview deploys with PostHog script loading
- [x] Check PostHog dashboard for incoming events from nixtlaverse docs