### PR TITLE
[chore] remove timegpt docs from nixtlaverse build pipeline

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,13 +19,6 @@ jobs:
           path: docs
           ref: docs-preview
 
-      - name: Clone nixtla
-        uses: actions/checkout@v4
-        with:
-          repository: Nixtla/nixtla
-          path: nixtla
-          ref: docs-preview
-
       - name: Clone statsforecast
         uses: actions/checkout@v4
         with:
@@ -77,7 +70,6 @@ jobs:
 
       - name: Copy documentation and merge configs
         run: |
-          cp -R nixtla docs/
           cp -R statsforecast docs/
           cp -R mlforecast docs/
           cp -R neuralforecast docs/

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,13 +19,6 @@ jobs:
           path: docs
           ref: docs
 
-      - name: Clone nixtla
-        uses: actions/checkout@v4
-        with:
-          repository: Nixtla/nixtla
-          path: nixtla
-          ref: docs
-
       - name: Clone statsforecast
         uses: actions/checkout@v4
         with:
@@ -77,7 +70,6 @@ jobs:
       
       - name: Copy documentation and merge configs
         run: |
-          cp -R nixtla docs/
           cp -R statsforecast docs/
           cp -R mlforecast docs/
           cp -R neuralforecast docs/


### PR DESCRIPTION
This PR removes the step of cloning `timegpt` docs into nixtlaverse.

This PR doesn't break the `timegpt-docs` pipeline as it is separate from `nixtlaverse`