### PR TITLE
docs(nixtlaverse): fix preposition typo on home page

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -2,7 +2,7 @@
 title: "Nixtlaverse"
 ---
 
-The Nixtlaverse is composed by our open-source libraries, designed to provide a comprehensive, cutting-edge toolkit for time series forecasting. The Nixtla ecosystem is primarily built around five main libraries, each specializing in different aspects of time series forecasting:
+The Nixtlaverse is composed of our open-source libraries, designed to provide a comprehensive, cutting-edge toolkit for time series forecasting. The Nixtla ecosystem is primarily built around five main libraries, each specializing in different aspects of time series forecasting:
 
   <Card
     title="Nixtla AI"


### PR DESCRIPTION
## What

Fixes a small grammar typo on the Nixtlaverse landing page (`index.mdx`): "composed by" → "composed of".

## Why

Found during the 2026-07-19 daily site QA review. "The Nixtlaverse is composed by our open-source libraries" reads as a translation error; "composed of" is the correct preposition.

## How

- One-line text change in `index.mdx`.

## Testing

- [x] Visual diff only, no logic change.
- [ ] Manual: confirm the sentence reads correctly on the deployed preview.

## Checklist

- [x] Title follows conventional commits format
- [x] PR is focused on a single concern
- [x] Self-reviewed the diff before requesting review
- [x] No secrets, credentials, or PII in the diff