### PR TITLE
Add SynForecast to the nixtlaverse docs pipeline

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -68,6 +68,13 @@ jobs:
           path: coreforecast
           ref: docs-preview
 
+      - name: Clone synforecast
+        uses: actions/checkout@v4
+        with:
+          repository: Nixtla/synforecast
+          path: synforecast
+          ref: docs-preview
+
       - name: Copy documentation and merge configs
         run: |
           cp -R statsforecast docs/
@@ -77,6 +84,7 @@ jobs:
           cp -R utilsforecast docs/
           cp -R datasetsforecast docs/
           cp -R coreforecast docs/
+          cp -R synforecast docs/
           cd docs && python3 merge_docs.py
 
       - name: Commit and push changes

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -67,7 +67,14 @@ jobs:
           repository: Nixtla/coreforecast
           path: coreforecast
           ref: docs
-      
+
+      - name: Clone synforecast
+        uses: actions/checkout@v4
+        with:
+          repository: Nixtla/synforecast
+          path: synforecast
+          ref: docs
+
       - name: Copy documentation and merge configs
         run: |
           cp -R statsforecast docs/
@@ -77,6 +84,7 @@ jobs:
           cp -R utilsforecast docs/
           cp -R datasetsforecast docs/
           cp -R coreforecast docs/
+          cp -R synforecast docs/
           cd docs && python3 merge_docs.py
 
       - name: Commit and push changes

--- a/merge_docs.py
+++ b/merge_docs.py
@@ -24,7 +24,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
         'hierarchicalforecast': 'HierarchicalForecast',
         'utilsforecast': 'UtilsForecast',
         'datasetsforecast': 'DatasetsForecast',
-        'coreforecast': 'CoreForecast'
+        'coreforecast': 'CoreForecast',
+        'synforecast': 'SynForecast'
     }
     
     anchor_name = anchor_name_map.get(prefix)
@@ -59,7 +60,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
 
 
 repos = ['nixtla', 'statsforecast', 'mlforecast', 'neuralforecast',
-         'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast']
+         'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast',
+         'synforecast']
 
 main_config = json.loads(Path(fname).read_text())
 


### PR DESCRIPTION
Adds SynForecast to the documentation build pipeline, alongside the two navigation PRs against the `docs` and `docs-preview` branches.

## Changes

- `production.yml`: clone `Nixtla/synforecast` at `ref: docs`, and copy it in before the merge.
- `preview.yml`: same, at `ref: docs-preview`.
- `merge_docs.py`: register `synforecast` in `repos` and map it to the `SynForecast` anchor.

## Note on merge_docs.py

The copy that actually runs is the one on the `docs` / `docs-preview` branch, since the job checks that branch out into `docs/` and then runs `cd docs && python3 merge_docs.py`. This change keeps the `main` copy in sync; the functional change ships in the two branch PRs.

## Verification

Both jobs were replicated locally against the real `origin/docs` tree plus SynForecast's built docs output. The SynForecast anchor merges with 6 groups / 59 pages, every page path resolves to an existing `.mdx` file, and a diff against a baseline merge shows no change to any pre-existing anchor or to non-navigation config.

## Prerequisites

- `Nixtla/synforecast` must be public before the cross-repo `actions/checkout` can read it.
- The production path additionally needs SynForecast's `docs` branch, which its first release creates. Until then this step is inert.