### PR TITLE
Add SynForecast anchor to production docs navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -526,7 +526,7 @@
       },
       {
         "anchor": "SynForecast",
-        "icon": "flask",
+        "icon": "dna",
         "groups": []
       },
       {

--- a/docs.json
+++ b/docs.json
@@ -525,6 +525,11 @@
         ]
       },
       {
+        "anchor": "SynForecast",
+        "icon": "flask",
+        "groups": []
+      },
+      {
         "anchor": "CoreForecast",
         "icon": "truck-fast",
         "groups": [

--- a/merge_docs.py
+++ b/merge_docs.py
@@ -24,7 +24,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
         'hierarchicalforecast': 'HierarchicalForecast',
         'utilsforecast': 'UtilsForecast',
         'datasetsforecast': 'DatasetsForecast',
-        'coreforecast': 'CoreForecast'
+        'coreforecast': 'CoreForecast',
+        'synforecast': 'SynForecast'
     }
     
     anchor_name = anchor_name_map.get(prefix)
@@ -59,7 +60,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
 
 
 repos = ['nixtla', 'statsforecast', 'mlforecast', 'neuralforecast',
-         'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast']
+         'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast',
+         'synforecast']
 
 main_config = json.loads(Path(fname).read_text())
 


### PR DESCRIPTION
Companion to #43. Targets the `docs` branch, which is what the production job checks out and runs.

## Changes

- `docs.json`: add the `SynForecast` anchor, directly after `DatasetsForecast`. `merge_docs.py` only merges into an anchor that already exists, so without this entry the pipeline silently produces nothing for SynForecast.
- `merge_docs.py`: same registration as #43. This is the copy the job actually executes, since the job runs `cd docs && python3 merge_docs.py` against this branch's checkout.

`groups` is left empty on purpose — the merge step populates it on each run.

## Verification

Replicated the production job locally against this tree plus SynForecast's built docs: the anchor merges with 6 groups / 59 pages (Getting Started, Capabilities, Generators, Nixtlaverse, API Reference), every page path resolves to an existing `.mdx` file, and no pre-existing anchor changes.

The `docs.json` edit is a plain 5-line text insert; a JSON round-trip would have reformatted seven unrelated arrays and dropped the trailing newline on this hand-maintained file, so it was avoided.

## Note

This is inert until SynForecast's first release creates its `docs` branch. Safe to merge before then — the clone step in #43 is what would fail, and that is gated on the same prerequisite.