### PR TITLE
Add SynForecast anchor to preview docs navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -534,7 +534,7 @@
       },
       {
         "anchor": "SynForecast",
-        "icon": "flask",
+        "icon": "dna",
         "groups": []
       },
       {

--- a/docs.json
+++ b/docs.json
@@ -533,6 +533,11 @@
         ]
       },
       {
+        "anchor": "SynForecast",
+        "icon": "flask",
+        "groups": []
+      },
+      {
         "anchor": "CoreForecast",
         "icon": "truck-fast",
         "groups": [

--- a/merge_docs.py
+++ b/merge_docs.py
@@ -24,7 +24,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
         'hierarchicalforecast': 'HierarchicalForecast',
         'utilsforecast': 'UtilsForecast',
         'datasetsforecast': 'DatasetsForecast',
-        'coreforecast': 'CoreForecast'
+        'coreforecast': 'CoreForecast',
+        'synforecast': 'SynForecast'
     }
     
     anchor_name = anchor_name_map.get(prefix)
@@ -59,7 +60,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
 
 
 repos = ['nixtla', 'statsforecast', 'mlforecast', 'neuralforecast',
-         'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast']
+         'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast',
+         'synforecast']
 
 main_config = json.loads(Path(fname).read_text())
 


### PR DESCRIPTION
Companion to #43. Targets the `docs-preview` branch, which is what the preview job checks out and runs.

## Changes

- `docs.json`: add the `SynForecast` anchor, directly after `DatasetsForecast`. `merge_docs.py` only merges into an anchor that already exists, so without this entry the pipeline silently produces nothing for SynForecast.
- `merge_docs.py`: same registration as #43. This is the copy the job actually executes.

`groups` is left empty on purpose — the merge step populates it on each run.

## Verification

Replicated the preview job locally against this tree plus SynForecast's real `docs-preview` build: the anchor merges with 6 groups / 59 pages, every page path resolves to an existing `.mdx` file, and a diff against a baseline merge shows no change to any pre-existing anchor.

Unlike the production PR, this one takes effect on the next preview run as soon as `Nixtla/synforecast` is public — SynForecast's `docs-preview` branch already exists and is up to date.