### PR TITLE
Strip synforecast .git before copying into the docs tree

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -84,6 +84,7 @@ jobs:
           cp -R utilsforecast docs/
           cp -R datasetsforecast docs/
           cp -R coreforecast docs/
+          rm -rf synforecast/.git
           cp -R synforecast docs/
           cd docs && python3 merge_docs.py
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -84,6 +84,7 @@ jobs:
           cp -R utilsforecast docs/
           cp -R datasetsforecast docs/
           cp -R coreforecast docs/
+          rm -rf synforecast/.git
           cp -R synforecast docs/
           cd docs && python3 merge_docs.py
 


### PR DESCRIPTION
Fixes the SynForecast pages 404ing on the production site after #43.

## Problem

The pipeline copies each project checkout with `cp -R <project> docs/`, which includes the checkout's `.git` directory. For a directory that is **new** to the docs branch, the subsequent `git add .` stages it as an embedded repository (gitlink, mode `160000`) instead of its files. That's exactly what happened on the first production run after #43:

```
warning: adding embedded git repository: synforecast
 create mode 160000 synforecast
```

So the `docs` branch currently has a content-less pointer for `synforecast` — the merged navigation went live (`/synforecast` redirects) but every page 404s. The long-standing projects don't hit this because their files were already tracked, so `git add` ignores the stray `.git` and stages content updates as usual.

## Fix

`rm -rf synforecast/.git` before the copy, in both `production.yml` and `preview.yml`.

## After merging

Dispatch `production.yml` once — with the `.git` gone, `git add .` replaces the gitlink with the real file tree and Mintlify redeploys with the SynForecast pages.