### PR TITLE
Evict stale synforecast gitlink from the index before git add

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -94,10 +94,6 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git checkout docs-preview
-          # Evict any stale gitlink for synforecast from the index; git add
-          # will not descend into a path the index tracks as a submodule.
-          # Once the path is tracked as regular files, this unstages them
-          # and the git add below restages them, leaving the tree unchanged.
           git rm -r -q --cached --ignore-unmatch -- synforecast
           git add .
           git diff-index --quiet --cached HEAD -- || git commit -m "Update documentation"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -94,6 +94,11 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git checkout docs-preview
+          # Evict any stale gitlink for synforecast from the index; git add
+          # will not descend into a path the index tracks as a submodule.
+          # Once the path is tracked as regular files, this unstages them
+          # and the git add below restages them, leaving the tree unchanged.
+          git rm -r -q --cached --ignore-unmatch -- synforecast
           git add .
           git diff-index --quiet --cached HEAD -- || git commit -m "Update documentation"
           git push origin docs-preview --force

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -94,6 +94,11 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git checkout docs
+          # Evict any stale gitlink for synforecast from the index; git add
+          # will not descend into a path the index tracks as a submodule.
+          # Once the path is tracked as regular files, this unstages them
+          # and the git add below restages them, leaving the tree unchanged.
+          git rm -r -q --cached --ignore-unmatch -- synforecast
           git add .
           git diff-index --quiet --cached HEAD -- || git commit -m "Update documentation"
           git push origin docs --force

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -94,10 +94,6 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git checkout docs
-          # Evict any stale gitlink for synforecast from the index; git add
-          # will not descend into a path the index tracks as a submodule.
-          # Once the path is tracked as regular files, this unstages them
-          # and the git add below restages them, leaving the tree unchanged.
           git rm -r -q --cached --ignore-unmatch -- synforecast
           git add .
           git diff-index --quiet --cached HEAD -- || git commit -m "Update documentation"


### PR DESCRIPTION
Follow-up to #47, which was necessary but not sufficient. The SynForecast pages still 404.

## Problem

The `docs` and `docs-preview` branches already track `synforecast` as a gitlink (mode `160000`, committed by the first run before #47). Git treats an index gitlink as a submodule and `git add .` will not descend into that path — the copied plain files count as untracked content in a submodule and are silently ignored. That's why the post-#47 production run logged `Everything up-to-date` and committed nothing.

## Fix

Evict the cached entry immediately before `git add .` in both workflows:

```bash
git rm -r -q --cached --ignore-unmatch -- synforecast
```

- **Now** (gitlink in the index): removes the pointer, so `git add .` stages the real files.
- **Later** (files tracked normally): unstages them and the `git add .` restages the identical entries — tree unchanged, no spurious commits.
- `--ignore-unmatch` keeps it exit-0 under `bash -e` if the path is ever absent.

## Verification

- Full local simulation against real clones of the broken `docs` and `docs-preview` branches, running the exact workflow commands: gitlink replaced by a `040000 tree` with all 231 files; merged `docs.json` gets the SynForecast anchor (6 groups, 60 pages, landing `synforecast/index.html` — the target the live redirect already points at).
- Idempotency: a second full cycle from the healthy state stages nothing.
- Future releases: a modified page + a new page produce a commit with exactly those two changes.

## After merging

The push to main triggers the production workflow; the repair commit (gitlink → tree) necessarily changes the tree, so Mintlify redeploys with the pages. Preview repairs itself on its next run.