### PR TITLE
ci: clean hierarchical docs before copy

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -80,6 +80,7 @@ jobs:
           cp -R statsforecast docs/
           cp -R mlforecast docs/
           cp -R neuralforecast docs/
+          rm -rf docs/hierarchicalforecast
           cp -R hierarchicalforecast docs/
           cp -R utilsforecast docs/
           cp -R datasetsforecast docs/

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -80,6 +80,7 @@ jobs:
           cp -R statsforecast docs/
           cp -R mlforecast docs/
           cp -R neuralforecast docs/
+          rm -rf docs/hierarchicalforecast
           cp -R hierarchicalforecast docs/
           cp -R utilsforecast docs/
           cp -R datasetsforecast docs/


### PR DESCRIPTION
## What

Clean the existing HierarchicalForecast aggregate directory before copying the current generated documentation in both publication workflows.

## Why

Copying over the existing directory leaves pages that were removed from the source repository. Three stale pages currently produce six Mintlify broken link findings even though those pages no longer exist in the current HierarchicalForecast documentation build.

## How

1. Remove only `docs/hierarchicalforecast` immediately before the copy step.
2. Copy the current HierarchicalForecast build as before.
3. Leave every other repository aggregation step unchanged.

## Testing

1. Recreated the aggregate from fresh documentation branches.
2. Confirmed the three stale pages disappear after replacement.
3. Ran the native Mintlify broken link checker three times. Every run reported zero targeted findings, with the aggregate total improving from 259 to 250.
4. Inspected the complete diff, ran `git diff --check`, and scanned the diff for credentials.
5. Parsed both workflow files with Prettier. The existing style warning also occurs on untouched `main`.

## Checklist

* [x] The change is limited to HierarchicalForecast aggregation.
* [x] Preview and production use the same cleanup behavior.
* [x] No source documentation is deleted.

