### PR TITLE
Add ConformalForecast anchor to preview docs navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -674,6 +674,11 @@
         ]
       },
       {
+        "anchor": "ConformalForecast",
+        "icon": "bullseye",
+        "groups": []
+      },
+      {
         "anchor": "CoreForecast",
         "icon": "truck-fast",
         "groups": [

--- a/merge_docs.py
+++ b/merge_docs.py
@@ -25,7 +25,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
         'utilsforecast': 'UtilsForecast',
         'datasetsforecast': 'DatasetsForecast',
         'coreforecast': 'CoreForecast',
-        'synforecast': 'SynForecast'
+        'synforecast': 'SynForecast',
+        'conformalforecast': 'ConformalForecast'
     }
     
     anchor_name = anchor_name_map.get(prefix)
@@ -61,7 +62,7 @@ def merge_navigation(main_nav, sub_nav, prefix):
 
 repos = ['nixtla', 'statsforecast', 'mlforecast', 'neuralforecast',
          'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast',
-         'synforecast']
+         'synforecast', 'conformalforecast']
 
 main_config = json.loads(Path(fname).read_text())
 


### PR DESCRIPTION
Adds the `ConformalForecast` anchor to the preview navigation, ahead of wiring conformalforecast into the build pipeline.

**Merge order: this PR has no dependencies — merge it first.**

`merge_navigation` looks the anchor up by name and returns early when it is absent, so the anchor has to exist *before* the pipeline runs. Merge the pipeline PR first and the pages get copied in with nothing linking to them.

`groups` is left empty on purpose — `merge_docs.py` fills it at build time from conformalforecast’s own `docs.json`.

`merge_docs.py` is updated here too, because this branch’s copy is the one that actually executes: the workflow checks out `Nixtla/docs` at this ref and runs `merge_docs.py` from the checkout. The copy on `main` is kept in sync but never runs.

Same shape as #45, which did this for SynForecast.

### Verification

Ran the preview pipeline end to end against this branch’s tree plus the real `conformalforecast@docs-preview` checkout (`rm -rf .git`, `cp -R`, then the real `merge_docs.py`):

- ConformalForecast anchor resolves to **5 groups / 22 pages**
- every nav entry resolves to a real `.mdx` on disk
- `light.png`, `dark.png`, `favicon.svg` all present
- no other anchor emptied or reordered

### Blocks

- Nixtla/docs#pipeline (`add-conformalforecast-to-pipeline`) — must not merge until this one lands.