### PR TITLE
Add ConformalForecast anchor to production docs navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -682,6 +682,11 @@
         ]
       },
       {
+        "anchor": "ConformalForecast",
+        "icon": "bullseye",
+        "groups": []
+      },
+      {
         "anchor": "CoreForecast",
         "icon": "truck-fast",
         "groups": [

--- a/merge_docs.py
+++ b/merge_docs.py
@@ -25,7 +25,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
         'utilsforecast': 'UtilsForecast',
         'datasetsforecast': 'DatasetsForecast',
         'coreforecast': 'CoreForecast',
-        'synforecast': 'SynForecast'
+        'synforecast': 'SynForecast',
+        'conformalforecast': 'ConformalForecast'
     }
     
     anchor_name = anchor_name_map.get(prefix)
@@ -61,7 +62,7 @@ def merge_navigation(main_nav, sub_nav, prefix):
 
 repos = ['nixtla', 'statsforecast', 'mlforecast', 'neuralforecast',
          'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast',
-         'synforecast']
+         'synforecast', 'conformalforecast']
 
 main_config = json.loads(Path(fname).read_text())
 


### PR DESCRIPTION
Adds the `ConformalForecast` anchor to the production navigation, ahead of wiring conformalforecast into the build pipeline.

**Merge order: this PR has no dependencies — merge it alongside #52, before the pipeline PR.**

`merge_navigation` looks the anchor up by name and returns early when it is absent, so the anchor has to exist *before* the pipeline runs. Merge the pipeline PR first and the pages get copied in with nothing linking to them.

`groups` is left empty on purpose — `merge_docs.py` fills it at build time from conformalforecast’s own `docs.json`.

`merge_docs.py` is updated here too, because this branch’s copy is the one that actually executes: the workflow checks out `Nixtla/docs` at this ref and runs `merge_docs.py` from the checkout. The copy on `main` is kept in sync but never runs.

Same shape as #44, which did this for SynForecast.

### Verification

The equivalent merge was exercised end to end on the preview side (see #52): 5 groups / 22 pages, every nav entry resolving to a real file, no other anchor disturbed. This branch carries the identical 5-line anchor insert and the identical `merge_docs.py` change.

### Note on production readiness

The anchor is harmless to merge now, but production will not render ConformalForecast pages until `Nixtla/conformalforecast` actually has a `docs` branch. Nothing has published to it yet — it needs a release, or a `build-docs.yaml` `workflow_dispatch` with `deploy_target=production`. Until then the anchor sits empty on production, and the pipeline PR’s production clone step will fail.

### Blocks

- Nixtla/docs#pipeline (`add-conformalforecast-to-pipeline`) — must not merge until this one lands.