### PR TITLE
Add conformalforecast to nixtlaverse build pipeline

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -75,6 +75,13 @@ jobs:
           path: synforecast
           ref: docs-preview
 
+      - name: Clone conformalforecast
+        uses: actions/checkout@v4
+        with:
+          repository: Nixtla/conformalforecast
+          path: conformalforecast
+          ref: docs-preview
+
       - name: Copy documentation and merge configs
         run: |
           cp -R statsforecast docs/
@@ -86,6 +93,8 @@ jobs:
           cp -R coreforecast docs/
           rm -rf synforecast/.git
           cp -R synforecast docs/
+          rm -rf conformalforecast/.git
+          cp -R conformalforecast docs/
           cd docs && python3 merge_docs.py
 
       - name: Commit and push changes
@@ -94,7 +103,7 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git checkout docs-preview
-          git rm -r -q --cached --ignore-unmatch -- synforecast
+          git rm -r -q --cached --ignore-unmatch -- synforecast conformalforecast
           git add .
           git diff-index --quiet --cached HEAD -- || git commit -m "Update documentation"
           git push origin docs-preview --force

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -75,6 +75,13 @@ jobs:
           path: synforecast
           ref: docs
 
+      - name: Clone conformalforecast
+        uses: actions/checkout@v4
+        with:
+          repository: Nixtla/conformalforecast
+          path: conformalforecast
+          ref: docs
+
       - name: Copy documentation and merge configs
         run: |
           cp -R statsforecast docs/
@@ -86,6 +93,8 @@ jobs:
           cp -R coreforecast docs/
           rm -rf synforecast/.git
           cp -R synforecast docs/
+          rm -rf conformalforecast/.git
+          cp -R conformalforecast docs/
           cd docs && python3 merge_docs.py
 
       - name: Commit and push changes
@@ -94,7 +103,7 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git checkout docs
-          git rm -r -q --cached --ignore-unmatch -- synforecast
+          git rm -r -q --cached --ignore-unmatch -- synforecast conformalforecast
           git add .
           git diff-index --quiet --cached HEAD -- || git commit -m "Update documentation"
           git push origin docs --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+conformalforecast/

--- a/merge_docs.py
+++ b/merge_docs.py
@@ -25,7 +25,8 @@ def merge_navigation(main_nav, sub_nav, prefix):
         'utilsforecast': 'UtilsForecast',
         'datasetsforecast': 'DatasetsForecast',
         'coreforecast': 'CoreForecast',
-        'synforecast': 'SynForecast'
+        'synforecast': 'SynForecast',
+        'conformalforecast': 'ConformalForecast'
     }
     
     anchor_name = anchor_name_map.get(prefix)
@@ -61,7 +62,7 @@ def merge_navigation(main_nav, sub_nav, prefix):
 
 repos = ['nixtla', 'statsforecast', 'mlforecast', 'neuralforecast',
          'hierarchicalforecast', 'utilsforecast', 'datasetsforecast', 'coreforecast',
-         'synforecast']
+         'synforecast', 'conformalforecast']
 
 main_config = json.loads(Path(fname).read_text())
 


### PR DESCRIPTION
Clones `Nixtla/conformalforecast` into both the preview and production builds and registers it in `merge_docs.py` so its navigation folds into the `ConformalForecast` anchor.

## ⚠️ Depends on #52 and #53 — merge this LAST

| Order | PR | Base | Depends on |
|---|---|---|---|
| 1 | #52 — preview anchor | `docs-preview` | — |
| 2 | #53 — production anchor | `docs` | — |
| 3 | **this PR** | `main` | **#52 and #53** |

#52 and #53 are independent of each other and can merge in either order. This PR must come after both: `merge_navigation` looks the anchor up by name and returns early when it is absent, so merging this one first copies the pages in with nothing linking to them.

## What changed

- `preview.yml` / `production.yml`: a `Clone conformalforecast` step (`ref: docs-preview` / `docs`), the copy into the docs tree, and the staging fix below.
- `merge_docs.py`: `conformalforecast` added to `anchor_name_map` and `repos`.
- `.gitignore`: ignores a local `conformalforecast/` clone so it never gets committed here — the pipeline fetches it at build time.

## Carrying the #47 / #48 lessons up front

Both fixes are included from the start rather than after a broken run. `cp -R` brings the checkout’s `.git` along, which makes `git add` stage a *newly added* project as a gitlink instead of its files — the nav goes live while every page 404s. I reproduced it against the real checkout:

```
without fix -> mode=160000  files_staged=1     # gitlink, content-less pointer
with fix    -> mode=100644  files_staged=28    # real files
```

One deviation from #48: rather than adding a second `git rm --cached` line, conformalforecast joins the existing one as `-- synforecast conformalforecast`. Same behavior, and it keeps that line from growing once per package forever.

## Verification

Full preview pipeline simulated end to end — the real `docs-preview` tree with #52 applied, the real `conformalforecast@docs-preview` checkout, `rm -rf .git`, `cp -R`, then the real `merge_docs.py`:

- ConformalForecast anchor: **5 groups / 22 pages**
- every nav entry resolves to a real `.mdx` on disk
- `light.png`, `dark.png`, `favicon.svg` present; no stray `.git`, no `pull/` preview dirs
- no other anchor emptied or reordered
- both workflow files parse as valid YAML, 12 steps each

## Production will fail until conformalforecast has a `docs` branch

`Nixtla/conformalforecast` has no `docs` branch yet — nothing publishes to it except a release or a `build-docs.yaml` `workflow_dispatch` with `deploy_target=production`. Until that runs, the production clone step here fails and takes the nixtlaverse production build with it. Preview is unblocked today.

**Recommendation:** create that branch before merging this PR.